### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href='https://arxiv.org/abs/2509.16117'><img src='https://img.shields.io/badge/Paper%20(arXiv)-2509.16117-red?logo=arxiv'></a>  &nbsp;
   <a href='https://research.nvidia.com/labs/dir/DiffusionNFT'><img src='https://img.shields.io/badge/Website-green?logo=homepage&logoColor=white'></a> &nbsp;
   <a href='https://huggingface.co/worstcoder/SD3.5M-DiffusionNFT-MultiReward'><img src='https://img.shields.io/badge/Model-blue?logo=huggingface&logoColor='></a> &nbsp;
+  <a href="https://deepwiki.com/NVlabs/DiffusionNFT"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"></a>
 </div>
 
 ## Algorithm Overview


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/DiffusionNFT) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.